### PR TITLE
Fix path serialization and remove address derivation

### DIFF
--- a/src/helperV1.js
+++ b/src/helperV1.js
@@ -5,12 +5,13 @@ export function serializePathv1(path) {
     throw new Error("Invalid path.");
   }
 
-  const buf = Buffer.alloc(20);
-  buf.writeUInt32LE(0x80000000 + path[0], 0);
-  buf.writeUInt32LE(0x80000000 + path[1], 4);
-  buf.writeUInt32LE(0x80000000 + path[2], 8);
-  buf.writeUInt32LE(path[3], 12);
-  buf.writeUInt32LE(path[4], 16);
+  /* eslint no-bitwise: "off", no-plusplus: "off" */
+  const buf = Buffer.alloc(path.length * 4);
+  for (let i = 0; i < path.length; i++) {
+    // Harden all path components by ORing them with 0x80000000.
+    const hardened = (0x80000000 | path[i]) >>> 0;
+    buf.writeUInt32LE(hardened, i * 4);
+  }
 
   return buf;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,6 @@
  *  limitations under the License.
  ******************************************************************************* */
 
-import bech32 from "bech32";
 import { publicKeyv1, serializePathv1, signSendChunkv1 } from "./helperV1";
 import {
   APP_KEY,
@@ -53,16 +52,9 @@ export default class OasisApp {
     this.transport = transport;
     transport.decorateAppAPIMethods(
       this,
-      ["getVersion", "sign", "getAddressAndPubKey", "appInfo", "deviceInfo", "getBech32FromPK"],
+      ["getVersion", "sign", "getAddressAndPubKey", "appInfo", "deviceInfo"],
       scrambleKey,
     );
-  }
-
-  static getBech32FromPK(pk) {
-    if (pk.length !== 32) {
-      throw new Error("expected public key [32 bytes]");
-    }
-    return bech32.encode(DEFAULT_HRP, bech32.toWords(pk));
   }
 
   async serializePath(path) {

--- a/tests/basic.spec.js
+++ b/tests/basic.spec.js
@@ -3,13 +3,6 @@ import { serializePathv1 } from "../src/helperV1";
 
 const context = "oasis-core/consensus: tx for chain testing";
 
-test("check address conversion", async () => {
-  const pkStr = "17483e0883cf71e2fe4e12f42d1448d06f4274a73b9b6f560c5ed01a32745276";
-  const pk = Buffer.from(pkStr, "hex");
-  const addr = OasisApp.getBech32FromPK(pk);
-  expect(addr).toEqual("oasis1zayruzyreac79ljwzt6z69zg6ph5ya988wdk74svtmgp5vn52fmqg7uz69");
-});
-
 test("check prepare chunks function", async () => {
   const serializedPath = serializePathv1([44, 123, 5, 0, 3]);
   const message = Buffer.from(


### PR DESCRIPTION
This should make path serialization consistent with `oasis-core-ledger` and remove address derivation since the address is returned from the device anyway.