### PR TITLE
vue_example: update transfer tx format

### DIFF
--- a/vue_example/components/LedgerExample.vue
+++ b/vue_example/components/LedgerExample.vue
@@ -188,8 +188,8 @@ export default {
 
       const context = "oasis-core/consensus: tx for chain testing";
       const message = Buffer.from(
-        "pGNmZWWiY2dhcwBmYW1vdW50QGRib2R5omd4ZmVyX3RvWCBkNhaFWEyIEubmS3EVtRLTanD3U+vDV5fke4Obyq" +
-          "83CWt4ZmVyX3Rva2Vuc0Blbm9uY2UAZm1ldGhvZHBzdGFraW5nLlRyYW5zZmVy",
+        "pGNmZWWiY2dhcwBmYW1vdW50QGRib2R5omJ0b1UADPcg0nfdGTur44EtUOq7dlHKFQ5mYW1vdW50QGVub25jZQ" +
+          "BmbWV0aG9kcHN0YWtpbmcuVHJhbnNmZXI=",
         "base64",
       );
       response = await app.sign(path, context, message);


### PR DESCRIPTION
`xfer_to` -> `to`

to address 32 bytes -> 21 bytes. I'm using the "oasis1qqx0wgxjwlw3jwatuwqj6582hdm9rjs4pcnvzz66" address from ADR 0008 test vectors

`xfer_tokens` -> `amount`

with these corrections, it works on my device